### PR TITLE
downgraded SPI Speed to 500khz, changed usleep to delayMicroseconds s…

### DIFF
--- a/piGateway/rfm69.cpp
+++ b/piGateway/rfm69.cpp
@@ -38,7 +38,6 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#include <unistd.h>	//usleep
 #define MICROSLEEP_LENGTH 15
 
 #else
@@ -352,7 +351,7 @@ void RFM69::sendACK(const void* buffer, uint8_t bufferSize) {
   int16_t _RSSI = RSSI; // save payload received RSSI value
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
   uint32_t now = millis();
-  while (!canSend() && millis() - now < RF69_CSMA_LIMIT_MS) {    usleep(MICROSLEEP_LENGTH); /* printf(".");*/ receiveDone();}
+  while (!canSend() && millis() - now < RF69_CSMA_LIMIT_MS) {    delayMicroseconds(MICROSLEEP_LENGTH); /* printf(".");*/ receiveDone();}
   sendFrame(sender, buffer, bufferSize, false, true);
   RSSI = _RSSI; // restore payload RSSI
 }
@@ -430,7 +429,7 @@ void RFM69::interruptHandler() {
     thedata[1] = 0; // PAYLOADLEN
     thedata[2] = 0; //  TargetID
     wiringPiSPIDataRW(SPI_DEVICE, thedata, 3);
-    usleep(MICROSLEEP_LENGTH);
+    delayMicroseconds(MICROSLEEP_LENGTH);
 
     PAYLOADLEN = thedata[1];
     PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; // precaution
@@ -560,7 +559,7 @@ void RFM69::encrypt(const char* key) {
     }
 
     wiringPiSPIDataRW(SPI_DEVICE, thedata, 17);
-    usleep(MICROSLEEP_LENGTH);
+    delayMicroseconds(MICROSLEEP_LENGTH);
   }
 
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFE) | (key ? 1 : 0));
@@ -600,7 +599,7 @@ uint8_t RFM69::readReg(uint8_t addr)
   thedata[1] = 0;
 
   wiringPiSPIDataRW(SPI_DEVICE, thedata, 2);
-  usleep(MICROSLEEP_LENGTH);
+  delayMicroseconds(MICROSLEEP_LENGTH);
 
 //printf("%x %x\n", addr, thedata[1]);
   return thedata[1];
@@ -622,7 +621,7 @@ void RFM69::writeReg(uint8_t addr, uint8_t value)
   thedata[1] = value;
 
   wiringPiSPIDataRW(SPI_DEVICE, thedata, 2);
-  usleep(MICROSLEEP_LENGTH);
+  delayMicroseconds(MICROSLEEP_LENGTH);
 #else
   select();
   SPI.transfer(addr | 0x80);

--- a/piGateway/rfm69.h
+++ b/piGateway/rfm69.h
@@ -41,7 +41,7 @@
 #define RF69_IRQ_NUM          0
  
  //#define SPI_SPEED 1000000
-#define SPI_SPEED 2000000
+#define SPI_SPEED 500000
 #define SPI_DEVICE 0
 #else
 #include <Arduino.h>            //assumes Arduino IDE v1.0 or greater


### PR DESCRIPTION
I have downgraded the speed to 500khz. Should still be enough and my experiments with 2Mhz or 1Mhz or 3Mhz were not succesfull. I have also changed the usleep to delayMicroseconds from the wiringPi library. They state that usleep will always take 100 micro seconds and the wrapper function fixes this "problem". 
