### PR TITLE
piGateway now support for Odroid (C1+)

### DIFF
--- a/piGateway/Makefile
+++ b/piGateway/Makefile
@@ -1,3 +1,13 @@
+#
+# Makefile for piGateway
+#
+# Supported devices:
+# Arduino		use -DARDUINO
+# Raspberry Pi	use -DRASPBERRY
+# Odroid C1(+)	use -DODROIDC1
+#
+# make sure only your device is defined in the g++ lines.
+
 install : Gatewayd
 	cp Gatewayd /usr/local/bin
 	cp GatewaydService /etc/init.d/Gatewayd
@@ -13,11 +23,11 @@ uninstall:
 	rm /usr/local/bin/Gatewayd
 
 Gatewayd : Gateway.c rfm69.cpp rfm69.h rfm69registers.h networkconfig.h 
-	g++ Gateway.c rfm69.cpp -o Gatewayd -lwiringPi -lmosquitto -DRASPBERRY -DDAEMON
+	g++ Gateway.c rfm69.cpp -o Gatewayd -lwiringPi -lmosquitto -DODROIDC1 -DDAEMON
 
 Gateway : Gateway.c rfm69.cpp rfm69.h rfm69registers.h networkconfig.h 
-	g++ Gateway.c rfm69.cpp -o Gateway -lwiringPi -lmosquitto -DRASPBERRY
+	g++ Gateway.c rfm69.cpp -o Gateway -lwiringPi -lmosquitto -DODROIDC1 -DDEBUG
 
 SenderReceiver : SenderReceiver.c rfm69.cpp rfm69.h rfm69registers.h networkconfig.h 
-	g++ SenderReceiver.c rfm69.cpp -o SenderReceiver -lwiringPi -DRASPBERRY
+	g++ SenderReceiver.c rfm69.cpp -o SenderReceiver -lwiringPi -DODROIDC1
 

--- a/piGateway/networkconfig.h
+++ b/piGateway/networkconfig.h
@@ -9,14 +9,14 @@ File: Gateway.c
 This file hold the network configuration
 */
 
-#define NWC_NETWORK_ID 101
+#define NWC_NETWORK_ID 100
 #define NWC_NODE_ID 1
 // Frequency should be one of RF69_433MHZ RF69_868MHZ RF69_915MHZ
 #define NWC_FREQUENCY RF69_433MHZ
 // Set to 0 to disable encryption
 #define NWC_KEY_LENGTH 16
 // Must contain 16 characters
-#define NWC_KEY "xxxxxxxxxxxxxxxx"
+#define NWC_KEY "sampleEncryptKey"
 // Set to true is the RFM69 is high power, false otherwise
 #define NWC_RFM69H true
 // Set to true if you want to listen to all messages on the network, even if for  different nodes

--- a/piGateway/rfm69.cpp
+++ b/piGateway/rfm69.cpp
@@ -550,8 +550,7 @@ bool RFM69::receiveDone() {
 //ATOMIC_BLOCK(ATOMIC_FORCEON)
 //{
 #if defined(RASPBERRY) || defined(ODROIDC1)
-	// one or both defined, do nothing.
-#else
+	// one or both define
   noInterrupts(); // re-enabled in unselect() via setMode() or via receiveBegin()
 #endif
   if (_mode == RF69_MODE_RX && PAYLOADLEN > 0)

--- a/piGateway/rfm69.h
+++ b/piGateway/rfm69.h
@@ -42,6 +42,18 @@
  
 #define SPI_SPEED 500000
 #define SPI_DEVICE 0
+#elif ODROIDC1			// If ODROIDC1 is defined in the Makefile instead of RASPBERRY
+#include <stdint.h>
+
+#define RF69_MAX_DATA_LEN     61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
+
+#define RF69_SPI_CS           10 // SS is the SPI slave select pin, for instance D10 on atmega328, use the WiringPi numbering.
+#define RF69_IRQ_PIN          6	 // The interrupt pin on the OdroidC1, use WirintPi numbering.
+#define RF69_IRQ_NUM          0
+#define RF69_RST_PIN          5  // The reset pin should be pulled down by default, pull high for resetting 
+#define RF69_CLK_PIN          14 // The SPI CLK pin. Used for setting the pulldown and output mode.
+#define SPI_SPEED 500000
+#define SPI_DEVICE 0
 #else
 #include <Arduino.h>            //assumes Arduino IDE v1.0 or greater
 


### PR DESCRIPTION
Beside the option -DRASPBERRY added -DODROIDC1 option for the MakeFile.
rdm69.h and .cpp file will take different actions based on these options.
Added ODROIDC1 RST_PIN and defined this as output with pulldown.
Added ODROIDC1 CLK_PIN and defined this as output with pulldown.
Changed ODROIDC1 SPI_CS to pinmode OUTPUT and added pulldown.

In order to work you still need a 2.2K resistor between CLK pin and Gnd.

cleaning Odroid support commit
