### PR TITLE
Upd Gateway.c -MQTT subscription not working #23

### DIFF
--- a/piGateway/Gateway.c
+++ b/piGateway/Gateway.c
@@ -208,7 +208,7 @@ int main(int argc, char* argv[]) {
 
 	// Mosquitto subscription ---------
 	char subsciptionMask[128];
-	sprintf(subsciptionMask, "%s/%03d/#/down", MQTT_ROOT, theConfig.networkId);
+	sprintf(subsciptionMask, "%s/%03d/+/down/+", MQTT_ROOT, theConfig.networkId);
 	LOG("Subscribe to Mosquitto topic: %s\n", subsciptionMask);
 	mosquitto_subscribe(m, NULL, subsciptionMask, 0);
 	
@@ -481,11 +481,11 @@ const struct mosquitto_message *msg) {
 	Payload data;
 	uint8_t network;
 
-	sscanf(msg->topic, "RFM/%d/%d/%d", &network, &data.nodeID, &data.sensorID);
+	sscanf(msg->topic, "RFM/%d/%d/down/%d", &network, &data.nodeID, &data.sensorID);
 	if (strncmp(msg->topic, MQTT_ROOT, strlen(MQTT_ROOT)) == 0 && network == theConfig.networkId) {
 		
 		// extract the target network and the target node from the topic
-		sscanf(msg->topic, "RFM/%d/%d/%d", &network, &data.nodeID, &data.sensorID);
+		sscanf(msg->topic, "RFM/%d/%d/down/%d", &network, &data.nodeID, &data.sensorID);
 		
 		if (network == theConfig.networkId) {
 			// only process the messages to our network


### PR DESCRIPTION
in this issue comments by JojoS62 and myself, are now incorporated in this update.
comment by JojoS62:
Is this the actual version? I found the MQTT subscription is not working, the topic is not valid:
sprintf(subsciptionMask, "%s/%03d/#/down", MQTT_ROOT, theConfig.networkId);
The /down part is not allowed after the /#, but an /+ is ok. When the SensorID is appended then the correct topic name is: "%s/%03d/+/down/+"
and then by me:
another part i had to change in the code of Gateway.c, is where a recieved message from mosquitto is scanned with the missing part of the sensor ID, leading to sending a message to DeviceID=0, and not the correct one.
had to change 2 lines from:
sscanf(msg->topic, "RFM/%d/%d/%d", &network, &data.nodeID, &data.sensorID);
to:
sscanf(msg->topic, "RFM/%d/%d/down/%d", &network, &data.nodeID, &data.sensorID);